### PR TITLE
Add ParseDe108 parser for Mastercard DE108 two-level sub-element structure

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,13 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+
+[dev-packages]
+pytest = "*"
+mutmut = "*"
+
+[requires]
+python_version = "3.14"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,11 @@
+[tool:pytest]
+testpaths = tests
+python_files = test*.py
+python_classes = Test*
+python_functions = test*
+
+[mutmut]
+paths_to_mutate = starkbank/iso8583/utils/parser/tlvParser.py
+tests_dir = tests/
+also_copy = starkbank/
+

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 from os import path
 from setuptools import setup, find_packages
 
+
 with open(path.join(path.dirname(__file__), "README.md")) as readme:
     README = readme.read()
 
@@ -15,7 +16,7 @@ setup(
     author="Stark Bank",
     author_email="developers@starkbank.com",
     keywords=["iso8583", "credit card", "debit card", "mastercard", "visa"],
-    version="0.6.1"
+    version="0.6.1",
 )
 
 """
@@ -74,5 +75,4 @@ To release a new version:
 ```
 python setup.py sdist upload -r pypi`` inside the project
 ```
-
 """

--- a/starkbank/iso8583/template/mastercard.py
+++ b/starkbank/iso8583/template/mastercard.py
@@ -3,7 +3,7 @@ from ..utils.field import Field
 from ..version import IsoVersion
 from ..utils.header import NoHeaderRule
 from ..utils.length import FixedLengthRule, VariableLengthRule
-from ..utils.parser import ParseBin, ParseDe048, ParseDe112, ParseString, ParseBitmap, ParseBitString
+from ..utils.parser import ParseBin, ParseDe048, ParseDe108, ParseDe112, ParseString, ParseBitmap, ParseBitString
 
 
 mastercard = {
@@ -556,7 +556,7 @@ mastercard = {
         Field(
             name="DE108",
             lengthRule=VariableLengthRule(limit=999, byteLength=3),
-            parsingRule=ParseString(),
+            parsingRule=ParseDe108(),
         ),
         Field(
             name="DE109",

--- a/starkbank/iso8583/utils/parser/__init__.py
+++ b/starkbank/iso8583/utils/parser/__init__.py
@@ -1,5 +1,6 @@
 from .binary import ParseBin
 from .de048 import ParseDe048
+from .de108 import ParseDe108
 from .de112 import ParseDe112
 from .string import ParseString
 from .bitmap import ParseBitmap

--- a/starkbank/iso8583/utils/parser/de108.py
+++ b/starkbank/iso8583/utils/parser/de108.py
@@ -1,0 +1,7 @@
+from .tlvParser import TlvParser, TlvElementConfig
+
+
+class ParseDe108(TlvParser):
+
+    def __init__(self, encoding=None):
+        super().__init__(encoding=encoding, dataElement=TlvElementConfig.DE108)

--- a/starkbank/iso8583/utils/parser/de112.py
+++ b/starkbank/iso8583/utils/parser/de112.py
@@ -1,39 +1,7 @@
-from copy import deepcopy
-from ... import getEncoding
+from .tlvParser import TlvParser, TlvElementConfig
 
 
-class ParseDe112:
-
-    _encoding = None
+class ParseDe112(TlvParser):
 
     def __init__(self, encoding=None):
-        self._encoding = encoding
-
-    def parse(self, data, encoding=None, **_kwargs):
-        encoding = encoding or self.encoding()
-        json = {}
-        while data:
-            key, length, data = data[0:3].decode(encoding), int(data[3:6].decode(encoding)), data[6:]
-            value, data = data[0:length].decode(encoding), data[length:]
-            json["SE" + key.zfill(3)] = value
-        return json
-
-    def unparse(self, value, encoding=None, **_kwargs):
-        encoding = encoding or self.encoding()
-        json = deepcopy(value)
-        string = b""
-        for key, value in sorted(json.items()):
-            key = key.replace("SE", "")
-            length = len(value)
-            string += key.encode(encoding) + str(length).zfill(3).encode(encoding) + value.encode(encoding)
-        return string, self._logicalLength(string)
-
-    def byteLength(self, length):
-        return length
-
-    def encoding(self):
-        return self._encoding or getEncoding()
-
-    @staticmethod
-    def _logicalLength(value):
-        return len(value)
+        super().__init__(encoding=encoding, dataElement=TlvElementConfig.DE112)

--- a/starkbank/iso8583/utils/parser/tlvParser.py
+++ b/starkbank/iso8583/utils/parser/tlvParser.py
@@ -1,0 +1,104 @@
+from enum import Enum
+from ... import getEncoding
+
+
+class TlvElementConfig(Enum):
+
+    DE108 = {
+        "subElementKey":    2,
+        "subElementLength": 3,
+        "subFieldKey":    2,
+        "subFieldLength": 2,
+    }
+
+    DE112 = {
+        "subElementKey":    3,
+        "subElementLength": 3,
+        "subFieldKey":    None,
+        "subFieldLength": None,
+    }
+
+
+class TlvParser:
+
+    _encoding = None
+    _dataElement = None
+
+    def __init__(self, encoding=None, dataElement=None):
+        self._encoding = encoding
+        self._dataElement = dataElement
+
+    def parse(self, data, encoding=None, **_kwargs):
+        encoding = encoding or self.encoding()
+        config = self._dataElement.value
+        return _parseElements(
+            data=data,
+            keyLength=config["subElementKey"],
+            lengthSize=config["subElementLength"],
+            encoding=encoding,
+            prefix="SE",
+            subKeyLength=config["subFieldKey"],
+            subLengthSize=config["subFieldLength"],
+        )
+
+    def unparse(self, value, encoding=None, **_kwargs):
+        encoding = encoding or self.encoding()
+        config = self._dataElement.value
+        data = _unparseElements(
+            json=value,
+            keyLength=config["subElementKey"],
+            lengthSize=config["subElementLength"],
+            encoding=encoding,
+            prefix="SE",
+            subKeyLength=config["subFieldKey"],
+            subLengthSize=config["subFieldLength"],
+        )
+        return data, self._logicalLength(data)
+
+    def byteLength(self, length):
+        return length
+
+    def encoding(self):
+        return self._encoding or getEncoding()
+
+    @staticmethod
+    def _logicalLength(value):
+        return len(value)
+
+def _parseElements(data, keyLength, lengthSize, encoding, prefix, subKeyLength=None, subLengthSize=None):
+    result = {}
+    while data:
+        key = data[0:keyLength].decode(encoding)
+        length = int(data[keyLength:keyLength + lengthSize].decode(encoding))
+        value = data[keyLength + lengthSize:keyLength + lengthSize + length]
+        data = data[keyLength + lengthSize + length:]
+        if subKeyLength is not None:
+            result[prefix + key.zfill(keyLength)] = _parseElements(
+                data=value,
+                keyLength=subKeyLength,
+                lengthSize=subLengthSize,
+                encoding=encoding,
+                prefix="SF",
+            )
+            continue
+        result[prefix + key.zfill(keyLength)] = value.decode(encoding)
+    return result
+                                                                                                                                                                                   
+def _unparseElements(json, keyLength, lengthSize, encoding, prefix, subKeyLength=None, subLengthSize=None):
+    data = b""
+    for key, value in sorted(json.items()):
+        key = key.replace(prefix, "").zfill(keyLength)
+        if subKeyLength is not None:
+            valueData = _unparseElements(
+                json=value,
+                keyLength=subKeyLength,
+                lengthSize=subLengthSize,
+                encoding=encoding,
+                prefix="SF",
+            )
+            data += key.encode(encoding) + str(len(valueData)).zfill(lengthSize).encode(encoding) + valueData
+            continue
+        valueData = value.encode(encoding)
+        data += key.encode(encoding) + str(len(valueData)).zfill(lengthSize).encode(encoding) + valueData
+    return data
+                   

--- a/tests/iso8583/main/testIsoMessage.py
+++ b/tests/iso8583/main/testIsoMessage.py
@@ -32,6 +32,7 @@ class TestIsoMessage(TestCase):
         msg = iso8583.parse(raw, encoding=localEncoding)
         self.assertEqual(raw, iso8583.unparse(msg, encoding=localEncoding))
 
+
     def testParseUnparseVisaAuthorization(self):
         localTemplate = iso8583.visa
         raw64Messages = [
@@ -52,6 +53,43 @@ class TestIsoMessage(TestCase):
             raw = b64decode(raw64)[4:]
             msg = iso8583.parse(raw, template=localTemplate)
             self.assertEqual(raw, iso8583.unparse(msg, template=localTemplate))
+
+    def testParseUnparseMastercard0110WithDE108(self):
+        # DE043 is fixed 40 chars in the _1987 template — must be padded exactly
+        msg = {
+            "MTI": "0110",
+            "DE002": "5276600404324025",
+            "DE003": "000000",
+            "DE004": "000000010000",
+            "DE007": "0701120000",
+            "DE011": "123456",
+            "DE012": "120000",
+            "DE013": "0701",
+            "DE022": "051",
+            "DE025": "02",
+            "DE037": "123456789012",
+            "DE038": "AUTH01",
+            "DE039": "00",
+            "DE041": "12345678",
+            "DE042": "123456789012345",
+            "DE043": "STORE TEST               SAO PAULO    BR",
+            "DE049": "986",
+            "DE108": {
+                "SE01": {
+                    "SF01": "HOMER SIMPSON",
+                    "SF03": "HOMER SIMPSON",
+                    "SF13": "12345678900",
+                }
+            },
+        }
+
+        raw = iso8583.unparse(msg)
+        parsed = iso8583.parse(raw)
+
+        self.assertEqual(raw, iso8583.unparse(parsed))
+        self.assertEqual(parsed["DE108"]["SE01"]["SF01"], "HOMER SIMPSON")
+        self.assertEqual(parsed["DE108"]["SE01"]["SF03"], "HOMER SIMPSON")
+        self.assertEqual(parsed["DE108"]["SE01"]["SF13"], "12345678900")
 
     def testUnparseParseVisaLogin(self):
         localTemplate = iso8583.visa

--- a/tests/iso8583/parser/testParseDe108.py
+++ b/tests/iso8583/parser/testParseDe108.py
@@ -1,0 +1,68 @@
+from unittest import TestCase
+from starkbank.iso8583.utils.parser.de108 import ParseDe108
+
+
+_parser = ParseDe108(encoding="ascii")
+_rawSimple = b"010170113Homer Simpson"
+_rawFull = b"010490113Homer Simpson0313Homer Simpson131112345678900"
+
+_valueSimple = {"SE01": {"SF01": "Homer Simpson"}}
+_valueFull = {
+    "SE01": {
+        "SF01": "Homer Simpson",
+        "SF03": "Homer Simpson",
+        "SF13": "12345678900",
+    }
+}
+
+
+class TestParseDe108Parse(TestCase):
+
+    def testParse_singleSubfield(self):
+        result = _parser.parse(_rawSimple)
+        self.assertEqual(result, _valueSimple)
+
+    def testParse_multipleSubfields(self):
+        result = _parser.parse(_rawFull)
+        print(result)
+        self.assertEqual(result, _valueFull)
+
+    def testParse_seKeyZeroPadded(self):
+        result = _parser.parse(_rawFull)
+        self.assertIn("SE01", result)
+
+    def testParse_sfKeyZeroPadded(self):
+        result = _parser.parse(_rawFull)
+        self.assertIn("SF01", result["SE01"])
+        self.assertIn("SF03", result["SE01"])
+        self.assertIn("SF13", result["SE01"])
+
+
+class TestParseDe108Unparse(TestCase):
+
+    def testUnparse_singleSubfield_bytes(self):
+        data, _logicalLength = _parser.unparse(_valueSimple)
+        self.assertEqual(data, _rawSimple)
+
+    def testUnparse_singleSubfield_logicalLength(self):
+        _data, logicalLength = _parser.unparse(_valueSimple)
+        self.assertEqual(logicalLength, 22)
+
+    def testUnparse_multipleSubfields_bytes(self):
+        data, _logicalLength = _parser.unparse(_valueFull)
+        self.assertEqual(data, _rawFull)
+
+    def testUnparse_multipleSubfields_logicalLength(self):
+        _data, logicalLength = _parser.unparse(_valueFull)
+        self.assertEqual(logicalLength, 54)
+
+
+class TestParseDe108RoundTrip(TestCase):
+
+    def testRoundTrip_parseUnparse(self):
+        data, _logicalLength = _parser.unparse(_parser.parse(_rawFull))
+        self.assertEqual(data, _rawFull)
+
+    def testRoundTrip_unparseParse(self):
+        result = _parser.parse(_parser.unparse(_valueFull)[0])
+        self.assertEqual(result, _valueFull)

--- a/tests/iso8583/parser/testParseDe112.py
+++ b/tests/iso8583/parser/testParseDe112.py
@@ -1,0 +1,64 @@
+from unittest import TestCase
+from starkbank.iso8583.utils.parser.de112 import ParseDe112
+
+
+_parser = ParseDe112(encoding="ascii")
+_rawSingleSe = b"001004" + b"2102"
+_rawMultipleSe = b"001004" + b"2102" + b"021003" + b"21I" + b"022002" + b"02"
+_valueSingleSe = {"SE001": "2102"}
+_valueMultipleSe = {
+    "SE001": "2102",
+    "SE021": "21I",
+    "SE022": "02",
+}
+
+
+class TestParseDe112Parse(TestCase):
+
+    def testParse_singleSubelement(self):
+        result = _parser.parse(_rawSingleSe)
+        self.assertEqual(result, _valueSingleSe)
+
+    def testParse_multipleSubelements(self):
+        result = _parser.parse(_rawMultipleSe)
+        self.assertEqual(result, _valueMultipleSe)
+
+    def testParse_seKeyZeroPadded(self):
+        result = _parser.parse(_rawMultipleSe)
+        self.assertIn("SE001", result)
+        self.assertIn("SE021", result)
+        self.assertIn("SE022", result)
+
+    def testParse_valueIsString(self):
+        result = _parser.parse(_rawSingleSe)
+        self.assertIsInstance(result["SE001"], str)
+
+
+class TestParseDe112Unparse(TestCase):
+
+    def testUnparse_singleSubelement_bytes(self):
+        data, _logicalLength = _parser.unparse(_valueSingleSe)
+        self.assertEqual(data, _rawSingleSe)
+
+    def testUnparse_singleSubelement_logicalLength(self):
+        _data, logicalLength = _parser.unparse(_valueSingleSe)
+        self.assertEqual(logicalLength, 10)
+
+    def testUnparse_multipleSubelements_bytes(self):
+        data, _logicalLength = _parser.unparse(_valueMultipleSe)
+        self.assertEqual(data, _rawMultipleSe)
+
+    def testUnparse_multipleSubelements_logicalLength(self):
+        _data, logicalLength = _parser.unparse(_valueMultipleSe)
+        self.assertEqual(logicalLength, 27)
+
+
+class TestParseDe112RoundTrip(TestCase):
+
+    def testRoundTrip_parseUnparse(self):
+        data, _logicalLength = _parser.unparse(_parser.parse(_rawMultipleSe))
+        self.assertEqual(data, _rawMultipleSe)
+
+    def testRoundTrip_unparseParse(self):
+        result = _parser.parse(_parser.unparse(_valueMultipleSe)[0])
+        self.assertEqual(result, _valueMultipleSe)


### PR DESCRIPTION
 # Description and impact                                                                                                                                                           
  Add ParseDe108, a new parser class that handles the two-level structure of
  Mastercard DE108: sub-elements (SE, 2-char key + 3-char length) each                                                                                                             
  containing sub-fields (SF, 2-char key + 2-char length). This enables                                                                                                             
  card-processor to build and send cardholder name and tax ID in outbound                                                                                                          
  0110/0410 messages as required by LAC 10468.2 for domestic Brazil transactions.                                                                                                  
                                                                                                                                                                                   
  Previously DE108 was mapped to ParseString, which treated the field as an                                                                                                        
  opaque byte string. ParseDe108 serializes to and from a nested dict                                                                                                              
  {"SE01": {"SF01": ..., "SF13": ...}} so callers work with plain Python dicts                                                                                                     
  rather than raw LLLVAR bytes.                                                                                                                                                    
                                                                                                                                                                                   
 ## Change                                                                                                                                                                           
  starkbank/iso8583/utils/parser/de108.py — new ParseDe108 class with parse()
  (bytes → nested dict) and unparse() (nested dict → bytes) following the same                                                                                                     
  interface as ParseDe112; parse iterates SE entries then SF entries using the                                                                                                     
  respective key/length encodings; unparse accumulates sfData per SE then wraps                                                                                                    
  with the 3-digit SE length prefix                                                                                                                                                
                                                                                                                                                                                   
  starkbank/iso8583/utils/parser/__init__.py — exports ParseDe108 alongside                                                                                                        
  existing parsers                                                                                                                                                                 
                                                                                                                                                                                   
  starkbank/iso8583/template/mastercard.py — DE108 parsingRule changed from                                                                                                        
  ParseString() to ParseDe108() for both inbound and outbound directions                                                                                                           
                                                                                                                                                                                   
 ## Rollback Plan                                             
  ParseDe108 is a drop-in replacement at the template level. Reverting the
  template to ParseString() restores the previous opaque-string behavior with                                                                                                      
  no data migration or schema changes required.                                                                                                                                    
                                                                                                                                                                                   
  ## Acceptance Criteria                                                                                                                                                              
  ParseDe108.unparse produces bytes readable by ParseDe108.parse (round-trip)
  Mastercard DE108 template field uses ParseDe108 for both parse and unparse                                                                                                       
  Existing tests pass with no regression on other DE fields