### PR TITLE
Fix DE108 parsing for plain-text sub elements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     author="Stark Bank",
     author_email="developers@starkbank.com",
     keywords=["iso8583", "credit card", "debit card", "mastercard", "visa"],
-    version="0.7.0",
+    version="0.7.1",
 )
 
 """

--- a/starkbank/iso8583/utils/parser/tlvParser.py
+++ b/starkbank/iso8583/utils/parser/tlvParser.py
@@ -9,6 +9,10 @@ class TlvElementConfig(Enum):
         "subElementLength": 3,
         "subFieldKey":    2,
         "subFieldLength": 2,
+        # composite subelements per DMAS spec (Tables 1142-1145); plain-value ones
+        # must stay raw strings: SE06 (QR Dynamic Code Data), SE12/SE13 (Receiver/Sender
+        # Organization Name, GLB 11737.2, ans...140, no subfields) and any unknown
+        "compositeSubElements": ("01", "02", "03", "04", "05", "07", "08", "09", "10", "11"),
     }
 
     DE112 = {
@@ -39,10 +43,15 @@ class TlvParser:
             prefix="SE",
             subKeyLength=config["subFieldKey"],
             subLengthSize=config["subFieldLength"],
+            compositeKeys=config.get("compositeSubElements"),
         )
 
     def unparse(self, value, encoding=None, **_kwargs):
         encoding = encoding or self.encoding()
+        # jsons produced before TLV parsing hold the whole element as a string
+        if isinstance(value, str):
+            data = value.encode(encoding)
+            return data, self._logicalLength(data)
         config = self._dataElement.value
         data = _unparseElements(
             json=value,
@@ -65,14 +74,14 @@ class TlvParser:
     def _logicalLength(value):
         return len(value)
 
-def _parseElements(data, keyLength, lengthSize, encoding, prefix, subKeyLength=None, subLengthSize=None):
+def _parseElements(data, keyLength, lengthSize, encoding, prefix, subKeyLength=None, subLengthSize=None, compositeKeys=None):
     result = {}
     while data:
         key = data[0:keyLength].decode(encoding)
         length = int(data[keyLength:keyLength + lengthSize].decode(encoding))
         value = data[keyLength + lengthSize:keyLength + lengthSize + length]
         data = data[keyLength + lengthSize + length:]
-        if subKeyLength is not None:
+        if subKeyLength is not None and (compositeKeys is None or key in compositeKeys):
             result[prefix + key.zfill(keyLength)] = _parseElements(
                 data=value,
                 keyLength=subKeyLength,
@@ -88,7 +97,9 @@ def _unparseElements(json, keyLength, lengthSize, encoding, prefix, subKeyLength
     data = b""
     for key, value in sorted(json.items()):
         key = key.replace(prefix, "").zfill(keyLength)
-        if subKeyLength is not None:
+        # plain-value subelements parse to strings, composite ones to dicts;
+        # deciding by type keeps parse/unparse round-trips lossless
+        if subKeyLength is not None and isinstance(value, dict):
             valueData = _unparseElements(
                 json=value,
                 keyLength=subKeyLength,

--- a/tests/iso8583/parser/testParseDe108.py
+++ b/tests/iso8583/parser/testParseDe108.py
@@ -15,6 +15,20 @@ _valueFull = {
     }
 }
 
+# real-world MoneySend layout: composite SE01/SE03 mixed with plain-value SE12,
+# whose free text ("Homer Simpson") must not be parsed as SF TLVs
+_rawMixed = b"010410105Homer0307Simpson1202041311123456789000300605021412013Homer Simpson"
+_valueMixed = {
+    "SE01": {
+        "SF01": "Homer",
+        "SF03": "Simpson",
+        "SF12": "04",
+        "SF13": "12345678900",
+    },
+    "SE03": {"SF05": "14"},
+    "SE12": "Homer Simpson",
+}
+
 
 class TestParseDe108Parse(TestCase):
 
@@ -37,6 +51,32 @@ class TestParseDe108Parse(TestCase):
         self.assertIn("SF03", result["SE01"])
         self.assertIn("SF13", result["SE01"])
 
+    def testParse_plainSubElementStaysRawString(self):
+        result = _parser.parse(_rawMixed)
+        self.assertEqual(result, _valueMixed)
+
+    def testParse_plainSubElementBeforeComposite(self):
+        result = _parser.parse(b"12013Homer Simpson010170113Homer Simpson")
+        self.assertEqual(result, {
+            "SE12": "Homer Simpson",
+            "SE01": {"SF01": "Homer Simpson"},
+        })
+
+    def testParse_networkSubElementOrder(self):
+        # order seen on the wire: SE01, SE12, SE03 (unparse emits sorted keys instead)
+        result = _parser.parse(b"010410105Homer0307Simpson13111234567890012020412013Homer Simpson03006050214")
+        self.assertEqual(result, _valueMixed)
+
+    def testParse_qrDynamicCodeDataStaysRawString(self):
+        # SE06 is plain per spec (Subfields: N/A) and can hold arbitrary QR payload
+        result = _parser.parse(b"0602600021BR.GOV.BCB.PIX0114+55")
+        self.assertEqual(result, {"SE06": "00021BR.GOV.BCB.PIX0114+55"})
+
+    def testParse_ebcdicEncoding(self):
+        parser = ParseDe108(encoding="cp500")
+        result = parser.parse(_rawMixed.decode("ascii").encode("cp500"))
+        self.assertEqual(result, _valueMixed)
+
 
 class TestParseDe108Unparse(TestCase):
 
@@ -56,6 +96,15 @@ class TestParseDe108Unparse(TestCase):
         _data, logicalLength = _parser.unparse(_valueFull)
         self.assertEqual(logicalLength, 54)
 
+    def testUnparse_plainSubElement_bytes(self):
+        data, _logicalLength = _parser.unparse(_valueMixed)
+        self.assertEqual(data, _rawMixed)
+
+    def testUnparse_wholeElementString_bytes(self):
+        data, logicalLength = _parser.unparse(_rawMixed.decode("ascii"))
+        self.assertEqual(data, _rawMixed)
+        self.assertEqual(logicalLength, len(_rawMixed))
+
 
 class TestParseDe108RoundTrip(TestCase):
 
@@ -66,3 +115,11 @@ class TestParseDe108RoundTrip(TestCase):
     def testRoundTrip_unparseParse(self):
         result = _parser.parse(_parser.unparse(_valueFull)[0])
         self.assertEqual(result, _valueFull)
+
+    def testRoundTrip_parseUnparse_plainSubElement(self):
+        data, _logicalLength = _parser.unparse(_parser.parse(_rawMixed))
+        self.assertEqual(data, _rawMixed)
+
+    def testRoundTrip_unparseParse_plainSubElement(self):
+        result = _parser.parse(_parser.unparse(_valueMixed)[0])
+        self.assertEqual(result, _valueMixed)


### PR DESCRIPTION
  ## Fix DE108 parsing for plain-text sub elements

  ### Problem
  v0.7.0 parses DE 108 (Additional Transaction Reference Data) as nested TLV, assuming every
  subelement contains SF-TLV subfields. Real-world Mastercard Send authorizations (0100) and
  Stand-In advices (0120) carry plain-value subelements — e.g. an undocumented SE12 holding the
  receiver's full name — which crashed the whole message parse:
  
      ValueError: invalid literal for int() with base 10: 'rc'   # int("rc") from "Ma[rc]os"

  ### Fix
  - `TlvElementConfig.DE108` now declares `compositeSubElements` — only subelements defined as
    composite in the DMAS spec (SE01–05, SE07–11, Tables 1142–1145) get subfield parsing;
    SE06 (QR Dynamic Code Data) and unknown subelements (e.g. SE12) stay raw strings.
  - `unparse` decides by value type (dict → SF-TLV, string → raw), keeping round-trips lossless.
  - `unparse` accepts the whole element as a plain string, for jsons produced before v0.7.0.

  Outbound DE108 built from composite subelements (e.g. SE01 with holder name/tax ID in
  0110/0410 responses) is byte-identical to v0.7.0.

  ### Tests
  9 new cases: mixed composite + plain parse, wire subelement order, cp500 encoding, SE06 QR
  payload, legacy whole-string unparse, and byte-exact round-trips both directions.
